### PR TITLE
Add playback controls to pendulum snake viewer

### DIFF
--- a/pendulum_snake.py
+++ b/pendulum_snake.py
@@ -6,15 +6,36 @@ each pendulum has its own natural period, the collection of pendulums forms
 beautiful wave patterns over time – often called a pendulum snake or pendulum
 wave machine.
 
+Quick start
+-----------
+
+1. Install the requirements with ``pip install -r requirements.txt``.
+2. Launch the viewer with ``python pendulum_snake.py``.
+3. Use the control buttons and sliders at the bottom of the window to
+   experiment with the setup.
+
 How to use the viewer
 ---------------------
 
-Run the script with ``python examples/pendulum_snake.py``. A Matplotlib window
-opens with animated pendulums and five sliders:
+Run the script with ``python pendulum_snake.py``. A Matplotlib window opens
+with animated pendulums, three playback buttons, and five sliders that let you
+experiment in real time:
+
+``Start``
+    Resume the motion if you have paused it.
+
+``Pause``
+    Freeze the pendulums so you can talk through the current pattern or adjust
+    the sliders without the scene moving.
+
+``Restart``
+    Jump back to the initial release so the next swing shows the effect of your
+    latest parameter choices from the beginning.
 
 ``Pendulums``
     Sets how many individual pendulums form the wave. More pendulums mean a
-    longer wave train and richer interference patterns.
+    longer wave train and richer interference patterns. Try values between 8
+    and 16 to watch the travelling "beats" slowly move across the array.
 
 ``Base length``
     Sets the starting string length (in metres) of the first pendulum. Longer
@@ -24,33 +45,39 @@ opens with animated pendulums and five sliders:
 ``Length step``
     Adds extra length to each subsequent pendulum. A larger step makes the
     difference between adjacent pendulum periods more pronounced, changing the
-    wave interference pattern.
+    wave interference pattern. Small steps (0.02–0.04 m) keep neighbouring
+    bobs almost in sync, while larger steps produce faster ripples.
 
 ``Release angle``
     Controls the starting angle (in degrees) away from vertical. Higher values
-    give the bobs more energy and wider swings.
+    give the bobs more energy and wider swings. Keep it modest (< 15°) if you
+    want the motion to remain close to the simple pendulum approximation.
 
 ``Gravity``
     Adjusts the gravitational acceleration in metres per second squared. This
     allows experimentation with how the wave evolves under different gravity
     strengths (for example on the Moon vs. Earth).
 
-You can pause the animation by pressing the ``space`` key. Drag any slider to
-see immediately how the motion changes. Try small length steps for slow,
-mesmerising waves and larger steps for quicker, more chaotic-looking motion.
+Use the on-screen buttons to start, pause, or restart the wave (restart jumps
+back to the initial release so changes take effect from the beginning). Drag
+any slider to see immediately how the motion changes. Try small length steps
+for slow, mesmerising waves and larger steps for quicker, more
+chaotic-looking motion.
 """
 
 from __future__ import annotations
 
 import itertools
 from dataclasses import dataclass
-from typing import Callable, Iterable, List, Sequence, Tuple
+from typing import Callable, List, Sequence, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.animation import FuncAnimation
 from matplotlib.axes import Axes
-from matplotlib.widgets import Slider
+from matplotlib.artist import Artist
+from matplotlib.lines import Line2D
+from matplotlib.widgets import Button, Slider
 
 
 @dataclass
@@ -112,8 +139,8 @@ class PendulumSnakePlot:
     def __init__(self, ax: Axes, params: PendulumParameters) -> None:
         self.ax = ax
         self.params = params
-        self.string_artists: List[plt.Line2D] = []
-        self.bob_artists: List[plt.Line2D] = []
+        self.string_artists: List[Line2D] = []
+        self.bob_artists: List[Line2D] = []
         self._setup_axes()
         self._create_artists()
 
@@ -144,6 +171,8 @@ class PendulumSnakePlot:
         for color in colors:
             (string_line,) = self.ax.plot([], [], lw=2.5, color=color, alpha=0.85)
             (bob_point,) = self.ax.plot([], [], "o", color=color, ms=8)
+            string_line.set_animated(True)
+            bob_point.set_animated(True)
             self.string_artists.append(string_line)
             self.bob_artists.append(bob_point)
 
@@ -153,7 +182,7 @@ class PendulumSnakePlot:
         self._update_limits()
         self._create_artists()
 
-    def draw(self, time_s: float) -> Sequence[plt.Artist]:
+    def draw(self, time_s: float) -> Sequence[Artist]:
         lengths = self.params.lengths()
         omegas = self.params.angular_frequencies(lengths)
         angles = self.params.release_angle_rad * np.cos(omegas * time_s)
@@ -213,13 +242,52 @@ def _make_sliders(
     return count_slider, base_slider, step_slider, angle_slider, gravity_slider
 
 
+def _make_buttons(
+    fig: plt.Figure,
+    on_start: Callable[[object], None],
+    on_pause: Callable[[object], None],
+    on_restart: Callable[[object], None],
+) -> Tuple[Button, Button, Button]:
+    """Create buttons to control the animation playback."""
+
+    button_width = 0.18
+    button_height = 0.05
+    button_left = 0.12
+    button_gap = 0.02
+    button_bottom = 0.31
+
+    ax_start = fig.add_axes([button_left, button_bottom, button_width, button_height], facecolor="#101820")
+    ax_pause = fig.add_axes(
+        [button_left + button_width + button_gap, button_bottom, button_width, button_height],
+        facecolor="#101820",
+    )
+    ax_restart = fig.add_axes(
+        [button_left + 2 * (button_width + button_gap), button_bottom, button_width, button_height],
+        facecolor="#101820",
+    )
+
+    start_button = Button(ax_start, "Start", hovercolor="#1f4068")
+    pause_button = Button(ax_pause, "Pause", hovercolor="#1f4068")
+    restart_button = Button(ax_restart, "Restart", hovercolor="#1f4068")
+
+    start_button.on_clicked(on_start)
+    pause_button.on_clicked(on_pause)
+    restart_button.on_clicked(on_restart)
+
+    for button in (start_button, pause_button, restart_button):
+        button.label.set_color("#e0e6f8")
+
+    return start_button, pause_button, restart_button
+
+
 def _add_instructions(fig: plt.Figure) -> None:
     instruction_text = (
-        "Play with the sliders to see how pendulum length, gravity, and release angle\n"
-        "affect the travelling wave pattern. Longer strings swing slower, so a small\n"
-        "length step (for example 0.03 m) keeps neighbouring pendulums nearly in phase.\n"
-        "A larger step exaggerates the timing differences and produces faster-moving\n"
-        "waves. Try lowering gravity to imagine the wave on the Moon!"
+        "Use the buttons to start, pause, or restart the wave, then play with the sliders\n"
+        "to see how pendulum length, gravity, and release angle affect the pattern.\n"
+        "Longer strings swing slower, so a small length step (for example 0.03 m) keeps\n"
+        "neighbouring pendulums nearly in phase. A larger step exaggerates the timing\n"
+        "differences and produces faster-moving waves. Try lowering gravity to imagine\n"
+        "the wave on the Moon!"
     )
     fig.text(0.12, 0.94, instruction_text, fontsize=9, color="#e0e6f8", va="top")
 
@@ -234,24 +302,57 @@ def main() -> None:
     pendulum_plot = PendulumSnakePlot(ax, params)
     _add_instructions(fig)
 
+    time_elapsed = 0.0
+    timestep = 1 / 60
+    is_running = True
+
     def on_slider_change() -> None:
         pendulum_plot.refresh()
+        pendulum_plot.draw(time_elapsed)
         fig.canvas.draw_idle()
 
-    _make_sliders(fig, params, on_slider_change)
+    # Keep references to the slider widgets so they remain responsive.
+    sliders = _make_sliders(fig, params, on_slider_change)
+    fig._pendulum_sliders = sliders  # type: ignore[attr-defined]
 
-    def frame_generator() -> Iterable[float]:
-        time_s = 0.0
-        timestep = 1 / 60  # seconds per frame
-        while True:
-            yield time_s
-            time_s += timestep
-
-    def animate(time_s: float):
-        artists = pendulum_plot.draw(time_s)
+    def animate(_frame_index: int):
+        nonlocal time_elapsed
+        artists = pendulum_plot.draw(time_elapsed)
+        time_elapsed += timestep
         return artists
 
-    FuncAnimation(fig, animate, frames=frame_generator(), interval=1000 / 60, blit=True)
+    animation = FuncAnimation(
+        fig,
+        animate,
+        frames=itertools.count(),
+        interval=1000 / 60,
+        blit=True,
+    )
+    fig._pendulum_animation = animation  # type: ignore[attr-defined]
+
+    def start_animation(_event: object) -> None:
+        nonlocal is_running
+        if not is_running:
+            animation.event_source.start()
+            is_running = True
+
+    def pause_animation(_event: object) -> None:
+        nonlocal is_running
+        if is_running:
+            animation.event_source.stop()
+            is_running = False
+
+    def restart_animation(_event: object) -> None:
+        nonlocal time_elapsed, is_running
+        time_elapsed = 0.0
+        pendulum_plot.draw(time_elapsed)
+        fig.canvas.draw_idle()
+        if not is_running:
+            animation.event_source.start()
+            is_running = True
+
+    buttons = _make_buttons(fig, start_animation, pause_animation, restart_animation)
+    fig._pendulum_buttons = buttons  # type: ignore[attr-defined]
 
     plt.show()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib>=3.6
+numpy>=1.23
+


### PR DESCRIPTION
## Summary
- document the new start, pause, and restart controls so families know how to explore the wave together
- add Matplotlib button widgets and animation state tracking so the viewer can pause, resume, or restart on demand
- keep the plot in sync when parameters or playback state changes so adjustments are visible immediately

## Testing
- python -m compileall pendulum_snake.py

------
https://chatgpt.com/codex/tasks/task_e_68d0d2156fd8832f93e6cea0c5408974